### PR TITLE
Use `jiro4989/setup-nim-action` `v1.3`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           path: ~/.nimble
           key: ${{ runner.os }}-nimble-stable
-      - uses: jiro4989/setup-nim-action@v1.1.4
+      - uses: jiro4989/setup-nim-action@v1.3
         with:
           nim-version: '1.4.4'
 


### PR DESCRIPTION
This is both a transition to the "floating" tag, and also an upgrade; at
the time of writing, this dependency is @ `v1.3.15`:

https://github.com/jiro4989/setup-nim-action/releases/tag/v1.3.15